### PR TITLE
Packaging: fix build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CWD := $(shell pwd)
 BASEDIR := $(CWD)
 PRINT_STATUS = export EC=$$?; cd $(CWD); if [ "$$EC" -eq "0" ]; then printf "SUCCESS!\n"; else exit $$EC; fi
-VERSION=0.0.1
+VERSION=1.2
 
 BUILDS    := .build
 DEPLOY    := $(BUILDS)/deploy

--- a/tendrl-api.spec
+++ b/tendrl-api.spec
@@ -54,6 +54,7 @@ Tendrl API httpd configuration.
 
 %install
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/lib/tendrl/errors
+install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/lib/tendrl/presenters
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/doc/tendrl/config
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/public
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/.deploy


### PR DESCRIPTION
Fix source tar not found and
directory lib/tendrl/presenters/ not found error during rpmbuild

tendrl-bug-id: Tendrl/api#62
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>