### PR TITLE
Node and Cluster list fix

### DIFF
--- a/cluster.rb
+++ b/cluster.rb
@@ -3,12 +3,14 @@ require './base'
 class Cluster < Base
 
   get '/GetClusterList' do
-    clusters = []
-    etcd.get('/clusters', recursive: true).children.each do |cluster|
-      clusters << recurse(cluster) 
+    begin
+      clusters = []
+      etcd.get('/clusters', recursive: true).children.each do |cluster|
+        clusters << recurse(cluster) 
+      end
+      clusters = ClusterPresenter.list(clusters)
+    rescue Etcd::KeyNotFound
     end
-    clusters = ClusterPresenter.list(clusters)
-    #clusters = load_stats(clusters)
     { clusters: clusters }.to_json
   end
 

--- a/node.rb
+++ b/node.rb
@@ -14,9 +14,12 @@ class Node < Base
   get '/GetNodeList' do
     nodes = []
     existing_cluster_ids = []
-
-    etcd.get('/nodes', recursive: true).children.each do |node|
-      nodes << recurse(node)
+    
+    begin
+      etcd.get('/nodes', recursive: true).children.each do |node|
+        nodes << recurse(node)
+      end
+    rescue Etcd::KeyNotFound
     end
 
     begin


### PR DESCRIPTION
The commit fixes listing of cluster and node when they are empty, the server responds with a empty array instead of a error message.