### PR TITLE
Fix service start issue due to missing Rakefile

### DIFF
--- a/tendrl-api.spec
+++ b/tendrl-api.spec
@@ -62,7 +62,7 @@ install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/lib/tendrl/valid
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/doc/tendrl/config
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/public
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/.deploy
-install -Dm 0644 *.ru Gemfile* $RPM_BUILD_ROOT%{_datadir}/%{name}
+install -Dm 0644 Rakefile *.ru Gemfile* $RPM_BUILD_ROOT%{_datadir}/%{name}
 install -Dm 0644 app/controllers/*.rb $RPM_BUILD_ROOT%{_datadir}/%{name}/app/controllers/
 install -Dm 0644 lib/*.rb $RPM_BUILD_ROOT%{_datadir}/%{name}/lib/
 install -Dm 0644 lib/tendrl/*.rb $RPM_BUILD_ROOT%{_datadir}/%{name}/lib/tendrl/


### PR DESCRIPTION
Add Rakefile into tendrl-api

tendrl-bug-id: Tendrl/api#108
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>