### PR TITLE
Logout and node list fixes

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,7 +16,7 @@ class SessionsController < ApplicationController
 
   delete '/logout' do
     user = Tendrl::User.authenticate_access_token(access_token)
-    user.delete_token(access_token)
+    user.delete_token(access_token) if user
     {}.to_json
   end
 

--- a/lib/tendrl/presenters/node_presenter.rb
+++ b/lib/tendrl/presenters/node_presenter.rb
@@ -7,6 +7,7 @@ module NodePresenter
       nodes_list.each do |node|
         node.each do |_, attributes|
           attributes.delete('service')
+          attributes.delete('messages')
           node_attr = attributes.delete('nodecontext')
           nodes << node_attr.merge(attributes)
         end


### PR DESCRIPTION
- Incorrect token sent to logout handled.
- GetNodeList endpoint ignores messages attribute