### PR TITLE
Use tags provided by individual flows

### DIFF
--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -48,7 +48,7 @@ class ClustersController < AuthenticatedUsersController
       flow,
       type: 'sds',
       integration_id: params[:cluster_id]
-    ).create(body, tags: flow.sds_tags)
+    ).create(body)
 
     status 202
     { job_id: job.job_id }.to_json
@@ -67,7 +67,7 @@ class ClustersController < AuthenticatedUsersController
       flow,
       type: 'sds',
       integration_id: params[:cluster_id]
-    ).create(body, tags: flow.sds_tags)
+    ).create(body)
 
     status 202
     { job_id: job.job_id }.to_json
@@ -87,7 +87,7 @@ class ClustersController < AuthenticatedUsersController
       flow,
       type: 'sds',
       integration_id: params[:cluster_id]
-    ).create(body, sds_tags: flow.sds_tags)
+    ).create(body)
 
     status 202
     { job_id: job.job_id }.to_json

--- a/lib/tendrl/flow.rb
+++ b/lib/tendrl/flow.rb
@@ -34,14 +34,22 @@ module Tendrl
       "#{sds_name.to_s.capitalize}#{@flow_name}"
     end
 
-    def sds_tags
-      if sds_name == 'gluster'
-        ['gluster/server']
-      elsif sds_name == 'ceph'
-        ["ceph/mon"]
-      else
-        []
+    def tags(context)
+      tags = []
+      return tags unless @flow['tags']
+      @flow['tags'].each do |tag|
+        finalized_tag = []
+        placeholders = tag.split('/')
+        placeholders.each do |placeholder|
+          if placeholder.start_with?('$')
+            finalized_tag << context[placeholder[1..-1]]
+          else
+            finalized_tag << placeholder
+          end
+        end
+        tags << finalized_tag.join('/')
       end
+      tags
     end
 
     def reference_attributes

--- a/lib/tendrl/job.rb
+++ b/lib/tendrl/job.rb
@@ -28,7 +28,7 @@ module Tendrl
       parameters['TendrlContext.integration_id'] = @integration_id
       @payload = default_payload.merge parameters: parameters
       @payload[:node_ids] = routing[:node_ids] if routing[:node_ids].present?
-      @payload[:tags] = routing[:tags] if routing[:tags].present?
+      @payload[:tags] = @flow.tags(parameters)
       Tendrl.etcd.set("/queue/#{@job_id}/status", value: 'new')
       Tendrl.etcd.set("/queue/#{@job_id}/payload", value: @payload.to_json)
       self

--- a/spec/controllers/nodes_controller_spec.rb
+++ b/spec/controllers/nodes_controller_spec.rb
@@ -24,6 +24,7 @@ describe NodesController do
   context 'import' do
 
     before do
+      stub_detected_cluster
       stub_definitions
       stub_job_creation
     end
@@ -105,7 +106,6 @@ describe NodesController do
         }
       }
       post '/CreateCluster', body.to_json, http_env
-      puts last_response.errors
       expect(last_response.status).to eq 202
     end
 

--- a/spec/fixtures/definitions/ceph.yaml
+++ b/spec/fixtures/definitions/ceph.yaml
@@ -1,0 +1,477 @@
+namespace.ceph:
+  flows:
+    CreatePool:
+      tags:
+       - "tendrl/integration/$TendrlContext.integration_id"
+      atoms:
+        - ceph.objects.Pool.atoms.Create
+      help: "Create Ceph Pool"
+      enabled: true
+      inputs:
+        mandatory:
+          - Pool.poolname
+          - Pool.pg_num
+          - Pool.min_size
+          - Pool.size
+        optional:
+          - Pool.type
+          - Pool.erasure_code_profile
+          - Pool.quota_enabled
+          - Pool.quota_max_objects
+          - Pool.quota_max_bytes
+      pre_run:
+        - ceph.objects.Pool.atoms.NamedPoolNotExists
+      run: ceph.flows.CreatePool
+      type: Create
+      uuid: faeab231-69e9-4c9d-b5ef-a67ed057f98b
+    CreateECProfile:
+      tags:
+       - "tendrl/integration/$TendrlContext.integration_id"
+      atoms:
+        - ceph.objects.ECProfile.atoms.Create
+      help: "Create EC Profile"
+      enabled: true
+      inputs:
+        mandatory:
+          - ECProfile.name
+          - ECProfile.k
+          - ECProfile.m
+        optional:
+          - ECProfile.plugin
+          - ECProfile.directory
+          - ECProfile.ruleset_failure_domain
+      run: ceph.flows.CreateECProfile
+      type: Create
+      uuid: faeab231-69e9-4c9d-b5ef-a67ed057f98d
+  objects:
+    GlobalDetails:
+      attrs:
+        status:
+          help: Cluster status
+          type: String
+      enabled: true
+      list: clusters/$TendrlContext.integration_id/GlobalDetails
+      value: clusters/$TendrlContext.integration_id/GlobalDetails
+      help: Cluster global details
+
+    SyncObject:
+      attrs:
+        updated:
+          help: "Updated"
+          type: String
+        sync_type:
+          help: "Sync Type eg: Mon Map, OSD Map etc"
+          type: String
+        version:
+          help: "version of sync type eg: 1.2.3"
+          type: String
+        when:
+          help: "time of data collection"
+          type: String
+        data:
+          help: "Sync data"
+          type: String
+      help: "Cluster sync data "
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/maps/$SyncObject.sync_type
+
+    ECProfile:
+      atoms:
+        Create:
+          enabled: true
+          help: "Create ec profile"
+          inputs:
+            mandatory:
+              - ECProfile.name
+              - ECProfile.k
+              - ECProfile.m
+            optional:
+              - ECProfile.plugin
+              - ECProfile.directory
+          name: "Create ec profile"
+          run: ceph.objects.ECProfile.atoms.Create
+          type: Create
+          uuid: 7a2df258-9b24-4fd3-a66f-ee346e2e3730
+        Delete:
+          enabled: true
+          help: "Delete ec profile"
+          inputs:
+            mandatory:
+              - ECProfile.name
+          name: "Delete ec profile"
+          run: ceph.objects.ECProfile.atoms.Delete
+          type: Delete
+          uuid: 7a2df258-9b24-4fd3-a66f-ee346e2e3740
+      flows:
+        DeleteECProfile:
+          tags:
+            - "tendrl/integration/$TendrlContext.integration_id"
+          atoms:
+            - ceph.objects.ECProfile.atoms.Delete
+          help: "Delete ec profile"
+          enabled: true
+          inputs:
+            mandatory:
+              - ECProfile.name
+          run: ceph.objects.ECProfile.flows.DeleteECProfile
+          type: Delete
+          uuid: 4ac41d8f-a0cf-420a-b2fe-18761e07f3b9
+      attrs:
+        name:
+          help: Name of the ec profile
+          type: String
+        k:
+          help: k value for ec profile
+          type: int
+        m:
+          help: m value for ec profile
+          type: int
+        plugin:
+          help: ec profile plugin
+          type: String
+        directory:
+          help: directory for ec profile
+          type: String
+        ruleset_failure_domain:
+          help: rule set failure domain for ec profile
+          type: String
+
+      enabled: true
+      list: clusters/$TendrlContext.integration_id/ECProfiles
+      value: clusters/$TendrlContext.integration_id/ECProfiles/$ECProfile.name
+      help: EC profile
+
+    Rbd:
+      atoms:
+        Create:
+          enabled: true
+          help: "Create rbd"
+          inputs:
+            mandatory:
+              - Rbd.pool_id
+              - Rbd.name
+              - Rbd.size
+          name: "Create Rbd"
+          run: ceph.objects.Rbd.atoms.Create
+          type: Create
+          uuid: 7a2df258-9b24-4fd3-a66f-ee346e2e3720
+        Delete:
+          enabled: true
+          help: "Delete rbd"
+          inputs:
+            mandatory:
+              - Rbd.pool_id
+              - Rbd.name
+          name: "Delete Rbd"
+          run: ceph_integration.objects.Rbd.atoms.Delete
+          type: Delete
+          uuid: 7a2df258-9b24-4fd3-a66f-ee346e2e3721
+        Resize:
+          enabled: true
+          help: "Resize Rbd"
+          inputs:
+            mandatory:
+              - Rbd.pool_id
+              - Rbd.name
+              - Rbd.size
+          name: "Resize Rbd"
+          run: ceph.objects.Rbd.atoms.Resize
+          type: Update
+          uuid: 7a2df258-9b24-4fd3-a66f-ee346e2e3722
+        RbdNotExists:
+          enabled: true
+          help: Check if rbd doesnt not exists
+          inputs:
+            mandatory:
+              - Rbd.pool_id
+              - Rbd.name
+          name: Rbd not exists
+          run: ceph.objects.Rbd.atoms.RbdNotExists
+          type: Get
+          uuid: 7a2df258-9b24-4fd3-a66f-ee346e2e3922
+        RbdExists:
+          enabled: true
+          help: Check if rbd exists
+          inputs:
+            mandatory:
+              - Rbd.pool_id
+              - Rbd.name
+          name: Rbd exists
+          run: ceph.objects.Rbd.atoms.RbdExists
+          type: Get
+          uuid: 7a2df258-9b24-4fd3-a66f-ee346e2e3922
+      flows:
+        CreateRbd:
+          tags:
+            - "tendrl/integration/$TendrlContext.integration_id"
+          atoms:
+            - ceph.objects.Rbd.atoms.Create
+          help: "Create Rbd"
+          enabled: true
+          inputs:
+            mandatory:
+              - Rbd.pool_id
+              - Rbd.name
+              - Rbd.size
+          pre_run:
+            - ceph.objects.Rbd.atoms.RbdNotExists
+          run: ceph.objects.Rbd.flows.CreateRbd
+          type: Create
+          uuid: 9bc41d8f-a0cf-420a-b2fe-18761e07f3d2
+        DeleteRbd:
+          tags:
+            - "tendrl/integration/$TendrlContext.integration_id"
+          atoms:
+            - ceph.objects.Rbd.atoms.Delete
+          help: "Delete Rbd"
+          enabled: true
+          inputs:
+            mandatory:
+              - Rbd.pool_id
+              - Rbd.name
+          pre_run:
+            - ceph.objects.Rbd.atoms.RbdExists
+          run: ceph.objects.Rbd.flows.DeleteRbd
+          post_run:
+            - ceph.objects.Rbd.atoms.RbdNotExists
+          type: Delete
+          uuid: 4ac41d8f-a0cf-420a-b2fe-18761e07f3a7
+        ResizeRbd:
+          tags:
+            - "tendrl/integration/$TendrlContext.integration_id"
+          atoms:
+            - ceph.objects.Rbd.atoms.Resize
+          help: "Resize Rbd"
+          enabled: true
+          inputs:
+            mandatory:
+              - Rbd.pool_id
+              - Rbd.name
+              - Rbd.size
+          pre_run:
+            - ceph.objects.Rbd.atoms.RbdExists
+          run: ceph.objects.Rbd.flows.ResizeRbd
+          type: Update
+          uuid: 4ac41d8f-a0cf-420a-b2fe-18761e07f3c9
+      attrs:
+        name:
+          help: Name of the rbd
+          type: String
+        size:
+          help: Size of the rbd (MB)
+          type: int
+        pool_id:
+          help: Id of the pool
+          type: String
+        flags:
+          help: flags for rbd
+          type: list
+        provisioned:
+          help: provisioned size
+          type: int
+        used:
+          help: used size
+          type: int
+      help: "Rbd"
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/Pools/$Pool.pool_id/Rbds/$Rbd.name
+      list: clusters/$TendrlContext.integration_id/Pools/$Pool.pool_id/Rbds
+
+    Pool:
+      atoms:
+        Create:
+          enabled: true
+          help: "Pool create Atom"
+          inputs:
+            mandatory:
+              - Pool.poolname
+              - Pool.pg_num
+              - Pool.min_size
+              - Pool.size
+            optional:
+              - Pool.type
+              - Pool.erasure_code_profile
+              - Pool.quota_enabled
+              - Pool.quota_max_objects
+              - Pool.quota_max_bytes
+          name: "Create Pool"
+          run: ceph.objects.Pool.atoms.Create
+          type: Create
+          uuid: bd0155a8-ff15-42ff-9c76-5176f53c13e0
+        Delete:
+          enabled: true
+          help: "Pool delete Atom"
+          inputs:
+            mandatory:
+              - Pool.pool_id
+          name: "Delete Pool"
+          run: ceph.objects.Pool.atoms.Delete
+          type: Delete
+          uuid: 9a2df258-9b24-4fd3-a66f-ee346e2e3720
+        Update:
+          enabled: true
+          help: "Pool update Atom"
+          inputs:
+            mandatory:
+              - Pool.pool_id
+            optional:
+              - Pool.poolname
+              - Pool.size
+              - Pool.min_size
+              - Pool.pg_num
+              - Pool.quota_enabled
+              - Pool.quota_max_objects
+              - Pool.quota_max_bytes
+          name: "Update Pool"
+          run: ceph.objects.Pool.atoms.Update
+          type: Update
+          uuid: 9a2df258-9b24-4fd3-a66f-ee346e2e3721
+        ValidUpdateParameters:
+          enabled: true
+          help: if update parametsr are valid
+          inputs:
+            mandatory:
+              - Pool.pool_id
+            optional:
+              - Pool.poolname
+              - Pool.size
+              - Pool.min_size
+              - Pool.pg_num
+              - Pool.quota_enabled
+              - Pool.quota_max_objects
+              - Pool.quota_max_bytes
+          name: Valid update parameters
+          run: ceph.objects.Pool.atoms.ValidUpdateParameters
+          type: Get
+          uuid: 9a2df258-9b24-4fd3-a66f-ee346e2e3791
+        NamedPoolNotExists:
+          enabled: true
+          help: check if named pool does not exist
+          inputs:
+            mandatory:
+              - Pool.poolname
+          name: Named pool not exists
+          run: ceph.objects.Pool.atoms.NamedPoolNotExists
+          type: Get
+          uuid: 9a2df258-9b24-4fd3-a66f-ee346e2e3891
+        PoolExists:
+          enabled: true
+          help: check if pool exists
+          inputs:
+            mandatory:
+              - Pool.pool_id
+          name: pool exists
+          run: ceph.objects.Pool.atoms.PoolExists
+          type: Get
+          uuid: 9a2df258-9b24-4fd3-a66f-ee346e2e3832
+        PoolNotExists:
+          enabled: true
+          help: check if pool does not exist
+          inputs:
+            mandatory:
+              - Pool.pool_id
+          name: pool not exists
+          run: ceph.objects.Pool.atoms.PoolNotExists
+          type: Get
+          uuid: 9a2df258-9b24-4fd3-a66f-ee346e2e3832
+      flows:
+        DeletePool:
+          tags:
+            - "tendrl/integration/$TendrlContext.integration_id"
+          atoms:
+            - ceph.objects.Pool.atoms.Delete
+          help: "Delete Ceph Pool"
+          enabled: true
+          inputs:
+            mandatory:
+              - Pool.pool_id
+          pre_run:
+            - ceph.objects.Pool.atoms.PoolExists
+          run: ceph.objects.Pool.flows.DeletePool
+          post_run:
+            - ceph.objects.Pool.atoms.PoolNotExists
+          type: Delete
+          uuid: 4ac41d8f-a0cf-420a-b2fe-18761e07f3b9
+        UpdatePool:
+          tags:
+            - "tendrl/integration/$TendrlContext.integration_id"
+          atoms:
+            - ceph.objects.Pool.atoms.Update
+          help: "Update Ceph Pool"
+          enabled: true
+          inputs:
+            mandatory:
+              - Pool.pool_id
+            optional:
+              - Pool.poolname
+              - Pool.size
+              - Pool.min_size
+              - Pool.pg_num
+              - Pool.quota_enabled
+              - Pool.quota_max_objects
+              - Pool.quota_max_bytes
+          pre_run:
+            - ceph.objects.Pool.atoms.PoolExists
+            - ceph.objects.Pool.atoms.ValidUpdateParameters
+          run: ceph.objects.Pool.flows.UpdatePool
+          type: Update
+          uuid: 4ac41d8f-a0cf-420a-b2fe-18761e07f3b2
+      attrs:
+        crush_ruleset:
+          help: "The ID of a CRUSH ruleset to use for this pool. The specified ruleset must exist."
+          type: Integer
+        erasure_code_profile:
+          help: "For erasure pools only.It must be an existing profile "
+          type: String
+        min_size:
+          help: "Sets the minimum number of replicas required for I/O in degraded state"
+          type: Integer
+        pg_num:
+          help: "The total number of placement groups for placement purposes."
+          type: Integer
+        pgp_num:
+          help: "The total number of placement groups for the pool."
+          type: Integer
+        pool_id:
+          help: "id of the pool"
+          type: Integer
+        poolname:
+          help: "Name of the Ceph pool"
+          type: String
+        type:
+          help: "Type of the Ceph pool(ec or replicated)"
+          type: String
+        size:
+          help: "Sets the minimum number of replicas required for I/O"
+          type: Integer
+        quota_enabled:
+          help: if quota enabled for the pool
+          type: bool
+        quota_max_objects:
+          help: maximum no of object
+          type: int
+        quota_max_bytes:
+          help: maximum no of bytes
+          type: int
+      help: "Pool"
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/Pools/$Pool.pool_id
+      list: clusters/$TendrlContext.integration_id/Pools
+    Utilization:
+      attrs:
+        total:
+          help: Total available size
+          type: int
+        used:
+          help: Used size
+          type: int
+        available:
+          help: Available size
+          type: int
+        pcnt_used:
+          help: Percent usage
+          type: int
+      help: "Overall utilization of cluster"
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/Utilization
+tendrl_schema_version: 0.3

--- a/spec/fixtures/definitions/gluster.yaml
+++ b/spec/fixtures/definitions/gluster.yaml
@@ -1,0 +1,380 @@
+namespace.gluster:
+  flows:
+    CreateVolume:
+      tags:
+       - "tendrl/integration/$TendrlContext.integration_id"
+      atoms:
+        - gluster.objects.Volume.atoms.Create
+      help: "Create Volume with bricks"
+      enabled: true
+      inputs:
+        mandatory:
+          - Volume.volname
+          - Volume.bricks
+        optional:
+          - Volume.replica_count
+          - Volume.disperse_count
+          - Volume.redundancy_count
+          - Volume.transport
+          - Volume.force
+          - Volume.tuned_profile
+      pre_run:
+        - gluster.objects.Volume.atoms.NamedVolumeNotExists
+      run: gluster.flows.CreateVolume
+      type: Create
+      uuid: 1951e821-7aa9-4a91-8183-e73bc8275b8e
+      version: 1
+  objects:
+    GlobalDetails:
+      attrs:
+        status:
+          help: status of the cluster
+          type: String
+      enabled: true
+      list: clusters/$TendrlContext.integration_id/GlobalDetails
+      value: clusters/$TendrlContext.integration_id/GlobalDetails
+      help: Clustr global details
+    Utilization:
+      attrs:
+        raw_capacity:
+          help: Raw capacity of cluster
+          type: int
+        usable_capacity:
+          help: Usable capacity
+          type: int
+        used_capacity:
+          help: Used capacity
+          type: int
+        pcnt_used:
+          help: Percent usage
+          type: int
+      enabled: true
+      list: clusters/$TendrlContext.integration_id/Utilization
+      value: clusters/$TendrlContext.integration_id/Utilization
+      help: Cluster utilization
+    Peer:
+      enabled: true
+      attrs:
+        hostname:
+          help: "Gluster Peer hostname"
+          type: String
+        peer_uuid:
+          help: "Gluster Peer uuid"
+          type: String
+        state:
+          help: "Gluster Peer state"
+          type: String
+        update:
+          help: "Last Peer update time"
+          type: String
+      value: clusters/$TendrlContext.integration_id/Peers/$Peer.peer_uuid
+      list: clusters/$TendrlContext.integration_id/Peers
+      help: Gluster cluster peers
+    SyncObject:
+      attrs:
+        cluster_id:
+          help: "Tendrl managed/generated cluster id for the sds being managed by Tendrl"
+          type: String
+        data:
+          help: raw data
+          type: String
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/raw_map/
+      list: clusters/TendrlContext.integration_id/TendrlContext/raw_map/
+      help: gluster cluster details
+    VolumeOptions:
+      attrs:
+        cluster_id:
+          help: "Tendrl managed/generated cluster id for the sds being managed by Tendrl"
+          type: String
+        vol_id:
+          help: Volume id
+          type: String
+        options:
+          help: options
+          type: dict
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/options
+      list: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/options
+      help: gluster volume options
+    Brick:
+      attrs:
+        vol_id:
+          help: Volume id
+          type: String
+        path:
+          help: Path of the brick
+          type: String
+        hostname:
+          help: Name of the host
+          type: String
+        port:
+          help: Brick port
+          type: int
+        status:
+          help: Status of the brick
+          type: String
+        filesystem_type:
+          help: File system type
+          type: String
+        mount_opts:
+          help: Mount options
+          type: String
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/Bricks/$Brick.path
+      list: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/Bricks
+      help: gluster volume bricks
+    Volume:
+      atoms:
+        Create:
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.volname
+              - Volume.bricks
+            optional:
+              - Volume.replica_count
+              - Volume.disperse_count
+              - Volume.redundancy_count
+              - Volume.transport
+              - Volume.force
+              - Volume.tuned_profile
+          name: create_volume
+          run: gluster.objects.Volume.atoms.Create
+          type: Create
+          uuid: 242f6190-9b37-11e6-950d-a24fc0d9649c
+          help: Create gluster volume
+        Delete:
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.volname
+              - Volume.vol_id
+            optional:
+              - Volume.format_bricks
+          name: delete_volume
+          run: gluster.objects.Volume.atoms.Delete
+          type: Delete
+          uuid: 242f6190-9b37-11e6-950d-a24fc0d9650c
+          help: Delete gluster volume
+        Start:
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.volname
+          name: start_volume
+          run: gluster.objects.Volume.atoms.Start
+          type: Start
+          uuid: 242f6190-9b37-11e6-950d-a24fc0d9651c
+          help: Start gluster volume
+        Stop:
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.volname
+          name: stop_volume
+          run: gluster.objects.Volume.atoms.Stop
+          type: Stop
+          uuid: 242f6190-9b37-11e6-950d-a24fc0d9652c
+          help: Stop gluster volume
+        NamedVolumeNotExists:
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.volname
+          name: named volume not exists
+          run: gluster.objects.Volume.atoms.NamedVolumeNotExists
+          type: Check
+          uuid: 242f6190-9b37-11e6-950d-a24fc0d9653d
+          help: check if named volume exists
+        VolumeExists:
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.vol_id
+          name: volume_exists
+          run: gluster.objects.Volume.atoms.VolumeExists
+          type: Check
+          uuid: 242f6190-9b37-11e6-950d-a24fc0d9653c
+          help: check if volume exists
+        VolumeNotExists:
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.vol_id
+          name: volume_not_exists
+          run: gluster.objects.Volume.atoms.VolumeNotExists
+          type: Check
+          uuid: 242f6190-9b37-11e6-950d-a24fc0d9654c
+          help: check if volume not exists
+        VolumeStarted:
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.vol_id
+          name: volume_started
+          run: gluster.objects.Volume.atoms.VolumeStarted
+          type: Check
+          uuid: 242f6190-9b37-11e6-950d-a24fc0d9655c
+          help: check if volume is started
+        VolumeStopped:
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.vol_id
+          name: volume_stopped
+          run: gluster.objects.Volume.atoms.VolumeStopped
+          type: Check
+          uuid: 242f6190-9b37-11e6-950d-a24fc0d9656c
+          help: check if volume is stopped
+      flows:
+        DeleteVolume:
+          tags:
+            - "tendrl/integration/$TendrlContext.integration_id"
+          atoms:
+            - gluster.objects.Volume.atoms.Delete
+          help: "Delete Volume"
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.volname
+              - Volume.vol_id
+            optional:
+              - Volume.format_bricks
+          post_run:
+            - gluster.objects.Volume.atoms.VolumeNotExists
+          pre_run:
+            - gluster.objects.Volume.atoms.VolumeExists
+          run: gluster.objects.Volume.flows.DeleteVolume
+          type: Delete
+          uuid: 1951e821-7aa9-4a91-8183-e73bc8275b9e
+          version: 1
+        StartVolume:
+          tags:
+            - "tendrl/integration/$TendrlContext.integration_id"
+          atoms:
+            - gluster.objects.Volume.atoms.Start
+          help: "Start Volume"
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.volname
+              - Volume.vol_id
+          pre_run:
+            - gluster.objects.Volume.atoms.VolumeExists
+            - gluster.objects.Volume.atoms.VolumeStopped
+          run: gluster.objects.Volume.flows.StartVolume
+          type: Start
+          uuid: 1951e821-7aa9-4a91-8183-e73bc8275b6e
+          version: 1
+        StopVolume:
+          tags:
+            - "tendrl/integration/$TendrlContext.integration_id"       
+          atoms:
+            - gluster.objects.Volume.atoms.Stop
+          help: "Stop Volume"
+          enabled: true
+          inputs:
+            mandatory:
+              - Volume.volname
+              - Volume.vol_id
+          pre_run:
+            - gluster.objects.Volume.atoms.VolumeExists
+            - gluster.objects.Volume.atoms.VolumeStarted
+          run: gluster.objects.Volume.flows.StopVolume
+          type: Stop
+          uuid: 1951e821-7aa9-4a91-8183-e73bc8275b5e
+          version: 1
+      attrs:
+        arbiter_count:
+          help: "Arbiter count of volume"
+          type: Integer
+        bricks:
+          help: "List of brick mnt_paths for volume"
+          type: List
+        deleted:
+          help: "Flag is volume is deleted"
+          type: Boolean
+        disperse_count:
+          help: "Disperse count of volume"
+          type: Integer
+        disperse_data_count:
+          help: "Disperse data count of volume"
+          type: Integer
+        force:
+          help: "If force execute the action"
+          type: Boolean
+        redundancy_count:
+          help: "Redundancy count of volume"
+          type: Integer
+        replica_count:
+          help: "Replica count of volume"
+          type: Integer
+        stripe_count:
+          help: "Stripe count of volume"
+          type: Integer
+        transport:
+          help: "Transport type for volume"
+          type: String
+        vol_id:
+          help: "ID of the gluster volume"
+          type: String
+        volname:
+          help: "Name of gluster volume"
+          type: String
+        vol_type:
+          help: "Type of the volume"
+          type: String
+        rebal_data:
+          help: "Rebalance data"
+          type: String
+        rebal_skipped:
+          help: "Skipped files while rebalance"
+          type: String
+        subvol_count:
+          help: "Count of subvolumes"
+          type: Integer
+        brick_count:
+          help: "Count of bricks"
+          type: Integer
+        cluster_id:
+          help: "UUID of the cluster"
+          type: String
+        snapd_inited:
+          help: "If snapd is initialized"
+          type: String
+        status:
+          help: "Status of the volume"
+          type: String
+        rebal_id:
+          help: "UUID of the rabalance task"
+          typoe: String
+        rebal_lookedup:
+          help: "Looked up files for rebalance"
+          type: Integer
+        snap_count:
+          help: "Count of the snapshots"
+          type: Integer
+        rebal_files:
+          help: "No of files rebalanced"
+          type: Integer
+        snapd_status:
+          help: "Status of snapd"
+          type: String
+        options:
+          help: "options list for volume"
+          type: json
+        quorum_status:
+          help: "Quorum status"
+          type: String
+        rebal_status:
+          help: "Status of rebalance task"
+          type: String
+        rebal_failures:
+          help: "Failed no of files for rebalance"
+          type: Integer
+      enabled: true
+      value: clusters/$TendrlContext.integration_id/Volumes/$Volume.vol_id/
+      list: clusters/$TendrlContext.integration_id/Volumes
+      help: gluster volume
+tendrl_schema_version: 0.3

--- a/spec/fixtures/definitions/master.yaml
+++ b/spec/fixtures/definitions/master.yaml
@@ -1,0 +1,530 @@
+---
+namespace.tendrl:
+  supported_sds:
+   - ceph
+   - gluster
+  min_reqd_gluster_ver: 3.9.0
+  min_reqd_ceph_ver: 10.2.5
+  ceph_provisioner: CephInstallerPlugin
+  gluster_provisioner: GdeployPlugin
+  tags:
+    tendrl-node-agent: "tendrl/node"
+    etcd: "tendrl/central-store"
+    tendrl-apid: "tendrl/server"
+    tendrl-monitor: "tendrl/monitor"
+    tendrl-gluster-integration: "tendrl/integration/gluster"
+    tendrl-ceph-integration: "tendrl/integration/ceph"
+    glusterd: "gluster/server"
+    ceph-mon: "ceph/mon"
+    ceph-osd: "ceph/osd"
+    gluster-provisioner: "provisioner/gluster"
+    ceph-provisioner: "provisioner/ceph"
+    ceph-installer: "provisioner/ceph"
+  flows:
+    CreateCluster:
+      tags: 
+        - "provisioner/$TendrlContext.sds_name"
+      help: "Create a cluster from scratch"
+      enabled: true
+      inputs:
+        mandatory:
+          - "Node[]"
+          - TendrlContext.cluster_name
+          - TendrlContext.sds_name
+          - TendrlContext.sds_version
+          - TendrlContext.cluster_id
+          - Cluster.public_network
+          - Cluster.cluster_network
+          - TendrlContext.integration_id
+          - Cluster.node_configuration
+          - Cluster.conf_overrides
+      run: tendrl.flows.CreateCluster
+      type: Create
+      uuid: 2f94a48a-05d7-408c-b400-e27827f4eacd
+      version: 1
+    ImportCluster:
+      tags:
+        - "detected_cluster/$DetectedCluster.detected_cluster_id"
+      help: "Import existing Gluster Cluster"
+      enabled: true
+      inputs:
+        mandatory:
+          - "Node[]"
+          - DetectedCluster.detected_cluster_id
+          - DetectedCluster.sds_pkg_name
+          - DetectedCluster.sds_pkg_version
+          - TendrlContext.integration_id
+      run: tendrl.flows.ImportCluster
+      type: Create
+      uuid: 2f94a48a-05d7-408c-b400-e27827f4edef
+      version: 1
+
+  objects:
+    Cluster:
+      internal: True
+      enabled: True
+      help: "Represents a cluster"
+      list: /clusters
+      attrs:
+        public_network:
+          help: Public Network cidr of the cluster
+          type: String
+        cluster_network:
+          help: Data Nework cidr of the cluster
+        node_configuration:
+          help: Node configuration for the cluster nodes
+          type: Dict[]
+        conf_overrides:
+          help: Configuration overrides for the cluster
+          type: Dict
+    DetectedCluster:
+      enabled: True
+      help: "DetectedCluster"
+      list: nodes/$NodeContext.node_id/DetectedCluster
+      attrs:
+        detected_cluster_id:
+          help: "Temporary id for the sds which is detected in Tendrl"
+          type: String
+        detected_cluster_name:
+          help: "Name of the sds which is detected in Tendrl"
+          type: String
+        sds_pkg_name:
+          help: Storage system package name
+          type: String
+        sds_pkg_version:
+          help: Storage system package version
+          type: String
+      value: nodes/$NodeContext.node_id/DetectedCluster
+    Cpu:
+      attrs:
+        architecture:
+          type: String
+        cores_per_socket:
+          type: String
+        cpu_family:
+          type: String
+        cpu_op_mode:
+          type: String
+        model:
+          type: String
+        model_name:
+          type: String
+        vendor_id:
+          type: String
+      enabled: true
+      value: nodes/$NodeContext.node_id/Cpu
+      help: "CPU"
+    Memory:
+      attrs:
+        total_size:
+          type: String
+        total_swap:
+          type: String
+      enabled: true
+      value: nodes/$NodeContext.node_id/Memory
+      help: "Node Memory"
+    Service:
+      atoms:
+       CheckServiceStatus:
+          enabled: true
+          inputs:
+            mandatory:
+              - Node.fqdn
+              - Service.name
+          outputs:
+            - status
+          name: "check whether the service is running"
+          help: "check whether the service is running"
+          run: tendrl.objects.Service.atoms.CheckServiceStatus
+          type: Create
+          uuid: eda0b13a-7362-48d5-b5ca-4b6d6533a5ab
+      attrs:
+        running:
+          type: String
+        exists:
+          type: String
+        service:
+          type: String
+      enabled: true
+      list: nodes/$NodeContext.node_id/Services
+      help: "Service"
+      value: nodes/$NodeContext.node_id/Services
+    Disk:
+      attrs:
+        disk_id:
+          help: "disk unique id"
+          type: String
+        device_name:
+          help: "disk name"
+          type: String
+        disk_kernel_name:
+          help: "disk internal kernel name"
+          type: String
+        parent_id:
+          help: "disk parent id"
+          type: String
+        parent_name:
+          help: "disk parent name"
+          type: String
+        disk_type:
+          help: "disk type"
+          type: String
+        fsuuid:
+          help: "file system uuid"
+          type: String
+        mount_point:
+          help: "disk mount point"
+          type: String
+        Model:
+          help: "disk model name"
+          type: String
+        vendor:
+          help: "disk vendor name"
+          type: String
+        used:
+          help: "disk used or not True/False"
+          type: String
+        serial_no:
+          help: "disk serial number"
+          type: String
+        rmversion:
+          help: "disk firmeware version"
+          type: String
+        fstype:
+          help: "file system type"
+          type: String
+        ssd:
+          help: "ssd is true / not"
+          type: String
+        size:
+          help: "size of the disk"
+          type: Integer
+        device_number:
+          help: "device number"
+          type: String
+        driver:
+          help: "driver"
+          type: String
+        group:
+          help: "disk group"
+          type: String
+        device:
+          help: "device"
+          type: String
+        bios_id:
+          help: "Bios id"
+          type: String
+        state:
+          help: "disk state"
+          type: String
+        drive_status:
+          help: "disk status"
+          type: String
+        label:
+          help: "label"
+          type: String
+        req_queue_size:
+          help: "request queue size"
+          type: String
+        driver_modules:
+          help: "driver modules"
+          type: String
+        mode:
+          help: "driver mode"
+          type: String
+        owner:
+          help: "driver owner"
+          type: String
+        min_io_size:
+          help: "min I/O size"
+          type: String
+        major_to_minor_no:
+          help: "major to minor number"
+          type: String
+        device_files:
+          help: "device files"
+          type: String
+        sysfs_busid:
+          help: "sysfs bus id"
+          type: String
+        alignement:
+          help: "alignement"
+          type: String
+        read_only:
+          help: "disk is read only or not"
+          type: String
+        read_ahead:
+          help: "read ahead"
+          type: String
+        removable_device:
+          help: "removable device or not"
+          type: String
+        scheduler_name:
+          help: "scheduler_name"
+          type: String
+        sysfs_id:
+          help: "sysfs id"
+          type: String
+        sysfs_device_link:
+          help: "sysfs device link"
+          type: String
+        geo_bios_edd:
+          help: "geometry bios edd"
+          type: String
+        geo_bios_legacy:
+          help: "geometry bios legacy"
+          type: String
+        geo_logical:
+          help: "geometry logical"
+          type: String
+        phy_sector_size:
+          help: "physical sector size"
+          type: String
+        discard_granularity:
+          help: "discard granularity"
+          type: String
+        discard_align_offset:
+          help: "discard align offset"
+          type: String
+        discard_max_bytes:
+          help: "discard max bytes"
+          type: String
+        discard_zeroes_data:
+          help: "discard zeroes data"
+          type: String
+        optimal_io_size:
+          help: "optimal I/O size"
+          type: String
+        log_sector_size:
+          help: "logical sector size"
+          type: String
+
+      enabled: true
+      list: nodes/$NodeContext.node_id/Disks
+      value: nodes/$NodeContext.node_id/Disks
+      help: "Disk"
+    Node:
+      atoms:
+        Cmd:
+          enabled: true
+          inputs:
+            mandatory:
+              - Node.cmd_str
+          outputs:
+            - Node.status
+          name: "Execute CMD on Node"
+          help: "Executes a command"
+          run: tendrl.objects.Node.atoms.Cmd
+          type: Create
+          uuid: dc8fff3a-34d9-4786-9282-55eff6abb6c3
+        CheckNodeUp:
+          enabled: true
+          inputs:
+            mandatory:
+              - Node.fqdn
+          outputs:
+            - Node.status
+          name: "check whether the node is up"
+          help: "Checks if a node is up"
+          run: tendrl.objects.Node.atoms.CheckNodeUp
+          type: Create
+          uuid: eda0b13a-7362-48d5-b5ca-4b6d6533a5ab
+      attrs:
+        cmd_str:
+          type: String
+        fqdn:
+          type: String
+        status:
+          type: Boolean
+      enabled: true
+      value: nodes/$NodeContext.node_id/Node
+      list: nodes/
+      help: 'Node'
+    NodeNetwork:
+      attrs:
+        interface:
+          help: "network interface name"
+          type: List
+        ipv4:
+          help: "ipv4 addresses"
+          type: List
+        ipv6:
+          help: "ipv6 addresses"
+          type: List
+        netmask:
+          help: "subnet masks"
+          type: List
+        subnet:
+          help: "subnet"
+          type: String
+        status:
+          help: "interface status up/down"
+          type: String
+        interface_id:
+          help: "unique id"
+          type: String
+        sysfs_id:
+          help: "sysfs id"
+          type: String
+        device_link:
+          help: "device link"
+          type: String
+        interface_type:
+          help: "interface type"
+          type: String
+        model:
+          help: "interface model"
+          type: String
+        driver_modules:
+          help: "driver modules"
+          type: String
+        driver:
+          help: "driver"
+          type: String
+        hw_address:
+          help: "hardware address"
+          type: String
+        link_detected:
+          help: "link detected"
+          type: String
+      enabled: true
+      list: nodes/$NodeContext.node_id/Networks
+      help: "Node wise network interface"
+      value: nodes/$NodeContext.node_id/Networks
+    Os:
+      attrs:
+        kernel_version:
+          type: String
+        os:
+          type: String
+        os_version:
+          type: String
+        selinux_mode:
+          type: String
+      enabled: true
+      value: nodes/$NodeContext.node_id/Os
+      help: "OS"
+    ClusterTendrlContext:
+      enabled: True
+      attrs:
+        integration_id:
+          help: "Tendrl managed/generated cluster id for the sds being managed by Tendrl"
+          type: String
+        sds_name:
+          help: "Name of the Tendrl managed sds, eg: 'gluster'"
+          type: String
+        sds_version:
+          help: "Version of the Tendrl managed sds, eg: '3.2.1'"
+          type: String
+        node_id:
+          help: "Tendrl ID for the managed node"
+          type: String
+        cluster_id:
+          help: "FSID (Ceph) or Gluster specific ID"
+          type: String
+        cluster_name:
+          help: Name of the cluster
+          type: String
+      value: clusters/$TendrlContext.integration_id/TendrlContext
+      help: "Tendrl context"
+    TendrlContext:
+      enabled: True
+      attrs:
+        integration_id:
+          help: "Tendrl managed/generated cluster id for the sds being managed by Tendrl"
+          type: String
+        sds_name:
+          help: "Name of the Tendrl managed sds, eg: 'gluster'"
+          type: String
+        sds_version:
+          help: "Version of the Tendrl managed sds, eg: '3.2.1'"
+          type: String
+        node_id:
+          help: "Tendrl ID for the managed node"
+          type: String
+        cluster_id:
+          help: UUID of the cluster
+          type: String
+        cluster_name:
+          help: Name of the cluster
+          type: String
+      value: nodes/$NodeContext.node_id/TendrlContext
+      help: "Tendrl context"
+    NodeContext:
+      attrs:
+        machine_id:
+          help: "Unique /etc/machine-id"
+          type: String
+        fqdn:
+          help: "FQDN of the Tendrl managed node"
+          type: String
+        node_id:
+          help: "Tendrl ID for the managed node"
+          type: String
+        tags:
+          help: "The tags associated with this node"
+          type: List
+        status:
+          help: "Node status"
+          type: String
+
+      enabled: true
+      list: nodes/$NodeContext.node_id/NodeContext
+      value: nodes/$NodeContext.node_id/NodeContext
+      help: Node Context
+    ClusterNodeContext:
+      attrs:
+        machine_id:
+          help: "Unique /etc/machine-id"
+          type: String
+        fqdn:
+          help: "FQDN of the Tendrl managed node"
+          type: String
+        node_id:
+          help: "Tendrl ID for the managed node"
+          type: String
+        tags:
+          help: "The tags associated with this node"
+          type: List
+        status:
+          help: "Node status"
+          type: String
+
+      enabled: true
+      list: clusters/$TendrlContext.integration_id/nodes/$NodeContext.node_id/NodeContext
+      value: clusters/$TendrlContext.integration_id/nodes/$NodeContext.node_id/NodeContext
+      help: Cluster leval Node Context
+    Job:
+      attrs:
+        job_id:
+          help: "job unique id"
+          type: String
+        status:
+          help: "job current status"
+          type: String
+        payload:
+          help: "dict"
+          type: Dict
+        errors:
+          help: "any errors occured or not"
+          type: String
+        children:
+          help: "ID of child jobs created by this job"
+          type: List
+      enabled: true
+      list: /queue
+      value: /queue
+      help: "jobs"
+    Platform:
+      attrs:
+        kernel_version:
+          type: String
+        os:
+          type: String
+        os_version:
+          type: String
+      enabled: true
+      help: "Platform of the Node"
+      value: nodes/$NodeContext.node_id/Platform
+      list: nodes/$NodeContext.node_id/Platform
+tendrl_schema_version: 0.3

--- a/spec/fixtures/detected_cluster.json
+++ b/spec/fixtures/detected_cluster.json
@@ -1,0 +1,9 @@
+{
+	"action": "get",
+	"node": {
+		"key": "/nodes/3a6cdc47-83b1-49cd-861c-5746066d8fb0/DetectedCluster/detected_cluster_id",
+		"value": "442a8d12-4790-498c-967c-a6ba4692a54d",
+		"modifiedIndex": 2173167,
+		"createdIndex": 2173167
+	}
+}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,18 @@ def stub_nodes
   )
 end
 
+def stub_detected_cluster
+  stub_request(
+    :get,
+    /http:\/\/127.0.0.1:4001\/v2\/keys\/nodes\/.*\/DetectedCluster\/detected_cluster_id/).
+  to_return(
+    status: 200,
+    body: File.read(
+      'spec/fixtures/detected_cluster.json'  
+    )
+  )
+end
+
 def stub_clusters(recursive=true)
   stub_request(
     :get,

--- a/spec/tendrl/flow_spec.rb
+++ b/spec/tendrl/flow_spec.rb
@@ -2,36 +2,78 @@ require 'spec_helper'
 
 RSpec.describe Tendrl::Flow do
 
-  before do
-    definitions = JSON.parse(File.read(
-      'spec/fixtures/definitions/tendrl_definitions_node_agent.json'
-    ))['node']['value']
-    Tendrl.node_definitions = YAML.load(definitions)
-  end
-
   context 'node' do
 
-    it 'initialize' do
+    before do
+      Tendrl.node_definitions = YAML.load_file(
+        'spec/fixtures/definitions/master.yaml'
+      )
+    end
+
+    it 'ImportCluster' do
       flow = Tendrl::Flow.new(
         'namespace.tendrl',
         'ImportCluster'
       )
-      expect(flow.objects.length).to eq(15)
-      expect(flow.type).to eq('create')
-      expect(flow.method).to eq('POST')
+      expect(flow.flow_name).to eq('ImportCluster')
+      expect(flow.tags({ 'DetectedCluster.detected_cluster_id' => '12345'})).to eq(['detected_cluster/12345'])
     end
+
+    it 'CreateCluster' do
+      flow = Tendrl::Flow.new(
+        'namespace.tendrl',
+        'CreateCluster'
+      )
+      expect(flow.flow_name).to eq('CreateCluster')
+      expect(flow.tags({ 'TendrlContext.sds_name' => 'ceph'})).to eq(['provisioner/ceph'])
+
+
+    end
+
 
   end
 
   context 'cluster' do
 
-    it 'initialize' do
-      flow = Tendrl::Flow.new(
-        'namespace.tendrl',
-        'ImportCluster'
-      )
+    context 'gluster' do
+
+      before do
+        Tendrl.cluster_definitions = YAML.load_file(
+          'spec/fixtures/definitions/gluster.yaml'
+        )
+      end
+
+      it 'CreateVolume' do
+        flow = Tendrl::Flow.new(
+          'namespace.gluster',
+          'CreateVolume'
+        )
+        expect(flow.flow_name).to eq('CreateVolume')
+        expect(flow.tags({ 'TendrlContext.integration_id' => '12345'})).to eq(['tendrl/integration/12345'])
+      end
+
+    end
+
+    context 'ceph' do
+
+      before do
+        Tendrl.cluster_definitions = YAML.load_file(
+          'spec/fixtures/definitions/ceph.yaml'
+        )
+      end
+
+      it 'CreatePool' do
+        flow = Tendrl::Flow.new(
+          'namespace.ceph',
+          'CreatePool'
+        )
+        expect(flow.flow_name).to eq('CreatePool')
+        expect(flow.tags({ 'TendrlContext.integration_id' => '12345'})).to eq(['tendrl/integration/12345'])
+      end
+
     end
 
   end
+
 
 end


### PR DESCRIPTION
- Added `master.yaml`, `gluster.yaml` and `ceph.yaml` as fixtures for flow tests
- Added tags per flow in job
- Find `detected_cluster_id` from the `node_ids` provided for ImportCluster
