### PR TITLE
Additional monitoring API's for iops, latency and throughput

### DIFF
--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -28,6 +28,21 @@ class MonitoringController < AuthenticatedUsersController
     { stats: response }.to_json
   end
 
+  get '/monitoring/node/:node_id/iops' do
+    response = @monitoring.node_iops(params[:node_id])
+    { stats: response }.to_json
+  end
+
+  get '/monitoring/node/:node_id/cpu' do
+    response = @monitoring.node_cpu(params[:node_id])
+    { stats: response }.to_json
+  end
+
+  get '/monitoring/node/:node_id/storage' do
+    response = @monitoring.node_storage(params[:node_id])
+    { stats: response }.to_json
+  end
+
   get '/monitoring/cluster/:cluster_id' do
     response = @monitoring.cluster(params[:cluster_id])
     { stats: response }.to_json

--- a/app/controllers/monitoring_controller.rb
+++ b/app/controllers/monitoring_controller.rb
@@ -13,8 +13,44 @@ class MonitoringController < AuthenticatedUsersController
     { stats: response }.to_json
   end
 
+  get '/monitoring/node/:node_id/memory' do
+    response = @monitoring.node_memory_percent_used(params[:node_id])
+    { stats: response }.to_json
+  end
+
+  get '/monitoring/node/:node_id/swap' do
+    response = @monitoring.node_swap_percent_used(params[:node_id])
+    { stats: response }.to_json
+  end
+
+  get '/monitoring/node/:node_id/throughput' do
+    response = @monitoring.node_throughput(params[:node_id], params[:type])
+    { stats: response }.to_json
+  end
+
   get '/monitoring/cluster/:cluster_id' do
     response = @monitoring.cluster(params[:cluster_id])
+    { stats: response }.to_json
+  end
+
+  get '/monitoring/cluster/:cluster_id/utilization' do
+    response = @monitoring.cluster_utilization(params[:cluster_id])
+    { stats: response }.to_json
+  end
+
+  get '/monitoring/cluster/:cluster_id/throughput' do
+    response = @monitoring.cluster_throughput(params[:cluster_id],
+                                              params[:type])
+    { stats: response }.to_json
+  end
+
+  get '/monitoring/cluster/:cluster_id/iops' do
+    response = @monitoring.cluster_iops(params[:cluster_id])
+    { stats: response }.to_json
+  end
+
+  get '/monitoring/cluster/:cluster_id/latency' do
+    response = @monitoring.cluster_latency(params[:cluster_id])
     { stats: response }.to_json
   end
 
@@ -28,9 +64,9 @@ class MonitoringController < AuthenticatedUsersController
     { stats: response }.to_json
   end
 
-  get '/monitoring/cluster/:cluster_id/utilization' do
-    response = @monitoring.cluster_utilization(params[:cluster_id])
+  get '/monitoring/system/:sds_name/throughput' do
+    response = @monitoring.system_throughput(params[:sds_name], params[:type])
     { stats: response }.to_json
   end
-
+  
 end

--- a/lib/tendrl/monitoring_api.rb
+++ b/lib/tendrl/monitoring_api.rb
@@ -22,6 +22,36 @@ module Tendrl
       []
     end
 
+    def node_memory_percent_used(node_id)
+      uri = URI(
+        "#{base_uri}/monitoring/nodes/#{node_id}/memory.percent-used/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
+    def node_swap_percent_used(node_id)
+      uri = URI(
+        "#{base_uri}/monitoring/nodes/#{node_id}/swap.percent-used/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
+    def node_throughput(node_id, type='cluster_network')
+      uri = URI(
+        "#{base_uri}/monitoring/nodes/#{node_id}/network_throughput-#{type}.gauge-used/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
     def cluster(cluster_id)
       uri = URI(
         "#{base_uri}/monitoring/clusters/#{cluster_id}/summary"
@@ -42,6 +72,36 @@ module Tendrl
       []
     end
 
+    def cluster_throughput(cluster_id, type='cluster_network')
+      uri = URI(
+        "#{base_uri}/monitoring/clusters/#{cluster_id}/throughput/#{type}/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
+    def cluster_iops(cluster_id)
+      uri = URI(
+        "#{base_uri}/monitoring/clusters/#{cluster_id}/iops/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
+    def cluster_latency
+      uri = URI(
+        "#{base_uri}/monitoring/clusters/#{cluster_id}/latency/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
     def system(sds_name)
       uri = URI(
         "#{base_uri}/monitoring/system/#{sds_name}/summary"
@@ -55,6 +115,16 @@ module Tendrl
     def system_utilization(sds_name)
       uri = URI(
         "#{base_uri}/monitoring/system/#{sds_name}/utilization/percent_used/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
+    def system_throughput(sds_name, type='cluster_network')
+      uri = URI(
+        "#{base_uri}/monitoring/system/#{sds_name}/throughput/#{type}/stats"
       )
       response = Net::HTTP.get(uri)
       JSON.parse(response)

--- a/lib/tendrl/monitoring_api.rb
+++ b/lib/tendrl/monitoring_api.rb
@@ -52,6 +52,36 @@ module Tendrl
       []
     end
 
+    def node_iops(node_id)
+      uri = URI(
+        "#{base_uri}/monitoring/nodes/#{node_id}/iops/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
+    def node_cpu(node_id)
+      uri = URI(
+        "#{base_uri}/monitoring/nodes/#{node_id}/cpu.cpu_system_user.percent-used/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
+    def node_storage(node_id)
+      uri = URI(
+        "#{base_uri}/monitoring/nodes/#{node_id}/storage.percent-used/stats"
+      )
+      response = Net::HTTP.get(uri)
+      JSON.parse(response)
+    rescue JSON::ParserError, Errno::ECONNREFUSED
+      []
+    end
+
     def cluster(cluster_id)
       uri = URI(
         "#{base_uri}/monitoring/clusters/#{cluster_id}/summary"
@@ -92,7 +122,7 @@ module Tendrl
       []
     end
 
-    def cluster_latency
+    def cluster_latency(cluster_id)
       uri = URI(
         "#{base_uri}/monitoring/clusters/#{cluster_id}/latency/stats"
       )

--- a/lib/tendrl/notification.rb
+++ b/lib/tendrl/notification.rb
@@ -22,7 +22,7 @@ module Tendrl
           end
           notifications << notification unless notification.blank?
         end
-        notifications.select{|e| e['priority'] == 'error' }.sort do |a,b|
+        notifications.select{|e| e['priority'] == 'notice' }.sort do |a,b|
           Time.parse(a['timestamp']) <=> Time.parse(b['timestamp'])
         end
       end


### PR DESCRIPTION
Provides following API's

## Node
```
GET /monitoring/node/:node_id/memory
GET /monitoring/node/:node_id/swap
GET /monitoring/node/:node_id/throughput?type=cluster_network
GET /monitoring/node/:node_id/throughput?type=public_network
GET /monitoring/node/:node_id/iops
GET /monitoring/node/:node_id/storage
GET /monitoring/node/:node_id/cpu
```

## Cluster
```
GET /monitoring/cluster/:cluster_id/throughput?type=cluster_network
GET /monitoring/cluster/:cluster_id/throughput?type=public_network
GET /monitoring/cluster/:cluster_id/iops
GET /monitoring/cluster/:cluster_id/latency
```

## System
sds_name could be ceph/gluster
```
GET /monitoring/system/:sds_name/throughput?type=cluster_network
GET /monitoring/system/:sds_name/throughput?type=public_network
```