### PR TITLE
Add tendrl-node-agent dependency

### DIFF
--- a/tendrl-api.spec
+++ b/tendrl-api.spec
@@ -29,6 +29,7 @@ Requires: rubygem-etcd
 Requires: rubygem-rack-protection >= 1.5.3
 Requires: rubygem-activesupport >= 4.2.6
 Requires: rubygem-sinatra >= 1.4.5
+Requires: tendrl-node-agent
 
 %description
 Collection of tendrl api.


### PR DESCRIPTION
Api now required tendrl-node-agent service which needs
tendrl-node-agent package.

Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>