### PR TITLE
etcd.sample.yml works without etcd auth by default

### DIFF
--- a/config/etcd.sample.yml
+++ b/config/etcd.sample.yml
@@ -3,21 +3,21 @@
   :base_key: ''
   :host: '127.0.0.1'
   :port: 2379
-  :user_name: 'username'
-  :password: 'password'
+  :user_name: ''
+  :password: ''
 
 :test:
   :base_key: ''
   :host: '127.0.0.1'
   :port: 2379
-  :user_name: 'username'
-  :password: 'password'
+  :user_name: ''
+  :password: ''
 
 :production:
   :base_key: ''
   :host: '127.0.0.1'
   :port: 2379
-  :user_name: 'username'
-  :password: 'password'
+  :user_name: ''
+  :password: ''
 
 


### PR DESCRIPTION
Change etcd.sample.yml so that it's not necessary to edit user_name
or password values when etcd authentication is disabled. This simplifies
both installation guide and tendrl-ansible.

tendrl-bug-id: Tendrl/api#294