### PR TITLE
Add etcd ssl certs config with preload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'bcrypt', '3.1.11'
 group :development do
   gem 'rubocop', require: false
   gem 'shotgun'
+  gem 'rb-readline'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       rack (>= 1.0)
     rainbow (2.1.0)
     rake (0.9.6)
+    rb-readline (0.5.5)
     rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -109,6 +110,7 @@ DEPENDENCIES
   puma (= 3.6.0)
   rack-test
   rake (= 0.9.6)
+  rb-readline
   rest-client
   rspec
   rubocop

--- a/config/etcd.sample.yml
+++ b/config/etcd.sample.yml
@@ -1,23 +1,18 @@
 ---
 :development:
-  :base_key: ''
   :host: '127.0.0.1'
   :port: 2379
-  :user_name: ''
-  :password: ''
-
-:test:
-  :base_key: ''
-  :host: '127.0.0.1'
-  :port: 2379
-  :user_name: ''
-  :password: ''
+  :ca_cert_file: ''
+  :client_cert_file: ''
+  :client_key_file: ''
+  :passphrase: ''
 
 :production:
-  :base_key: ''
   :host: '127.0.0.1'
   :port: 2379
-  :user_name: ''
-  :password: ''
+  :ca_cert_file: ''
+  :client_cert_file: ''
+  :client_key_file: ''
+  :passphrase: ''
 
 

--- a/config/initializers/etcd.rb
+++ b/config/initializers/etcd.rb
@@ -1,0 +1,25 @@
+config = Tendrl.load_config(ENV['RACK_ENV']).symbolize_keys
+etcd_config = { host: config[:host], port: config[:port] }
+
+if [config[:ca_cert_file], config[:client_cert_file], config[:client_key_file]]
+  .all?{|c| c.present? }
+  etcd_config.merge!(load_cert_config(config))
+end
+Tendrl.etcd = Etcd.client(etcd_config)
+
+def load_cert_config(config)
+  {
+    ssl:      true,
+    ca_file:  config[:ca_cert_file],
+    ssl_cert: load_client_cert(config[:client_cert_file]),
+    ssl_key:  load_client_key(config[:client_key_file], config[:passphrase])
+  }
+end
+
+def load_client_cert(path)
+  OpenSSL::X509::Certificate.new(File.read(path))
+end
+
+def load_client_key(path, passphrase)
+  OpenSSL::PKey::RSA.new(File.read(path), passphrase)
+end

--- a/spec/controllers/authenticated_users_controller_spec.rb
+++ b/spec/controllers/authenticated_users_controller_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe AuthenticatedUsersController do
     it 'current' do
       get "/current_user",{}, http_env
       expect(last_response.status).to eq 200
-      puts last_response.body
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe UsersController do
         stub_delete_user('quentin')
         stub_delete_email_notifications_index('quentin')
         delete "/users/quentin", {}, http_env
-        puts last_response.errors
         expect(last_response.status).to eq(200)
       end
 

--- a/tendrl-api.spec
+++ b/tendrl-api.spec
@@ -111,6 +111,7 @@ install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/log
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/tmp
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/config
 install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/config/puma
+install -dm 0755 --directory $RPM_BUILD_ROOT%{_datadir}/%{name}/config/initializers
 install -Dm 0644 Rakefile *.ru Gemfile* $RPM_BUILD_ROOT%{_datadir}/%{name}
 install -Dm 0644 app/controllers/*.rb $RPM_BUILD_ROOT%{_datadir}/%{name}/app/controllers/
 install -Dm 0644 app/forms/*.rb $RPM_BUILD_ROOT%{_datadir}/%{name}/app/forms/
@@ -125,6 +126,7 @@ install -Dm 0644 README.adoc Rakefile $RPM_BUILD_ROOT%{_datadir}/doc/tendrl
 install -Dm 0644 config/apache.vhost-ssl.sample $RPM_BUILD_ROOT%{_sysconfdir}/httpd/conf.d/tendrl-ssl.conf.sample
 install -Dm 0644 config/apache.vhost.sample $RPM_BUILD_ROOT%{_sysconfdir}/httpd/conf.d/tendrl.conf
 install -Dm 0644 config/puma/*.rb $RPM_BUILD_ROOT%{_datadir}/%{name}/config/puma/
+install -Dm 0644 config/initializers/*.rb $RPM_BUILD_ROOT%{_datadir}/%{name}/config/initializers/
 
 # Install SELinux interfaces and policy modules
 install -d %{buildroot}%{_datadir}/selinux/packages


### PR DESCRIPTION
Add config options in `etcd.yml` for adding certificate paths and passphrase. 
Load the etcd config only once on app preload.