### PR TITLE
Updated setup instructions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,11 +17,14 @@ group :development do
 end
 
 group :test do
-  gem 'rspec'
   gem 'rack-test'
   gem 'webmock'
   gem 'simplecov', :require => false
   gem 'rest-client'
+end
+
+group :test, :development do
+  gem 'rspec'
 end
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,4 +124,4 @@ RUBY VERSION
    ruby 2.0.0p598
 
 BUNDLED WITH
-   1.13.6
+   1.15.4

--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ development setups, both etcd and tendrl-api would reside on the same host.
 
 . Clone tendrl-api.
 
- $ git clone https://github.com/Tendrl/tendrl-api.git
+ $ git clone https://github.com/Tendrl/api.git
 
 . Install the gem dependencies, either..
 
@@ -84,7 +84,7 @@ fixtures to explore the API.
 The script will seed the etcd instance with mock cluster data and print a
 cluster uuid which can be used to make API requests.
 
- [tendrl-api] $ vendor/bin/rake etcd:seed # Seed the local store with cluster
+ [tendrl-api] $ vendor/bin/rake etcd:load_admin # Load default Tendrl admin in etcd
 
 . Start the development server:
 +

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,8 +2,7 @@ class SessionsController < ApplicationController
 
   post '/login' do
     body = request.body.read
-    attributes = JSON.parse(body).symbolize_keys
-
+    attributes = body.present? ? JSON.parse(body).symbolize_keys : {}
     user = Tendrl::User.authenticate(attributes[:username],
                                      attributes[:password])
     if user.present?


### PR DESCRIPTION
I had to make few changes to get this working
1. one rake task invokes rspec so, `rake -T` was failing since rspec wasn't available in development environment

2. rake task name given for loading user details to etcd was outdated

3. System was raising exception when empty data was provided in login request body