### PR TITLE
[WIP] dahorak's testing PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VERSION   := 1.5.5
 RELEASE   := 1
 COMMIT := $(shell git rev-parse HEAD)
 SHORTCOMMIT := $(shell echo $(COMMIT) | cut -c1-7)
+BRANCH := $(shell git symbolic-ref --short HEAD)
 
 all: srpm
 
@@ -28,6 +29,12 @@ update-release:
 	sed -i $(NAME).spec \
 	  -e "/^Release:/cRelease: $(shell date +"%Y%m%dT%H%M%S").$(SHORTCOMMIT)"
 
+update-release-pr:
+	sed -i $(NAME).spec \
+	  -e "/^Release:/cRelease: $(shell date +"%Y%m%dT%H%M%S").$(SHORTCOMMIT).$(BRANCH)"
+
 snapshot: update-release srpm
 
-.PHONY: dist rpm srpm update-release snapshot
+snapshot-pr: update-release-pr srpm
+
+.PHONY: dist rpm srpm update-release update-release-pr snapshot snapshot-pr


### PR DESCRIPTION
**Please do not merge this PR. It is just POC and might be even completely discarded. The main purpose is to test automated PR builds in CentOS CI.**

- `snapshot-pr` (more precisely `update-release-pr`) target in *Makefile* will append git branch
  name to the Release string
- this is useful for building packages from PR branch (to identify the
  PR related to the build)


depends on: tendrl-notifier/pr153 tendrl-commons/pr820