### PR TITLE
Remove firewall configuration reload

### DIFF
--- a/tendrl-api.spec
+++ b/tendrl-api.spec
@@ -103,10 +103,6 @@ getent passwd %{app_user} > /dev/null || \
 %post httpd
 setsebool -P httpd_can_network_connect 1
 systemctl enable tendrl-api >/dev/null 2>&1 || :
-firewall-cmd --reload >/dev/null 2>&1 || :
-
-%postun
-firewall-cmd --reload >/dev/null 2>&1 || :
 
 %files
 %license LICENSE


### PR DESCRIPTION
This patch will remove firewall configuration reload
from the spec file. Reloading firewall configuration
will be taken care by tendrl-ansible.

tendrl-bug-id: Tendrl/tendrl-ansible#49
Signed-off-by: Timothy Asir J <tjeyasin@redhat.com>