### PR TITLE
Clean up service files on uninstall/upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ config/sds
 coverage
 tmp
 log
+*.swp
+*.swo

--- a/tendrl-api.spec
+++ b/tendrl-api.spec
@@ -20,6 +20,7 @@ BuildArch: noarch
 
 BuildRequires: ruby
 BuildRequires: systemd-units
+BuildRequires: systemd
 
 Requires: ruby >= 2.0.0
 Requires: rubygem-activemodel >= 4.2.6
@@ -103,6 +104,15 @@ getent passwd %{app_user} > /dev/null || \
 %post httpd
 setsebool -P httpd_can_network_connect 1
 systemctl enable tendrl-api >/dev/null 2>&1 || :
+
+%post
+%systemd_post tendrl-api.service
+
+%preun
+%systemd_preun tendrl-api.service
+
+%postun
+%systemd_postun_with_restart tendrl-api.service
 
 %files
 %license LICENSE


### PR DESCRIPTION
This is a fix for #378, but requires verification.
We need to verify that the build process works, and all service-related functionality is maintained.

Adding vim tempfiles to .gitignore