### PR TITLE
Remove password_confirmation requirement

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,6 @@ namespace :etcd do
         email: 'admin@tendrl.org',
         role: 'admin',
         password: password,
-        password_confirmation: password,
         email_notifications: false
       })
       p 'Generated default admin'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,7 +74,6 @@ class UsersController < AuthenticatedUsersController
       :username,
       :role,
       :password,
-      :password_confirmation,
       :email_notifications
     )
   end

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -3,16 +3,13 @@ module Tendrl
     include ActiveModel::Validations
 
     attr_accessor :name, :username, :email, :password,
-      :password_confirmation, :role, :email_notifications
+      :role, :email_notifications
 
     validates :name, :username, presence: true, length: { minimum: 4, maximum: 100 }
 
-    validates :password, confirmation: true, length: { minimum: 8 }, if:
-      :password_required?
+    validates :password, length: { minimum: 8 }, if: :password_required?
 
-    validates :password_confirmation, presence: true, if: :password_required?
-
-    validates :email, format: { 
+    validates :email, format: {
       with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
     }
 
@@ -26,10 +23,9 @@ module Tendrl
       @user = user
       @name = params[:name] || user.name
       @username = params[:username] || user.username
-      @email = params[:email] || user.email 
+      @email = params[:email] || user.email
       @role = params[:role] || user.role
       @password = params[:password]
-      @password_confirmation = params[:password_confirmation]
       @email_notifications = if params[:email_notifications].nil?
                                user.email_notifications
                              else

--- a/docs/users.adoc
+++ b/docs/users.adoc
@@ -26,7 +26,7 @@ curl -H 'Content-Type: application/json' -H 'Authorization: Bearer
 d03ebb195dbe6385a7caeda699f9930ff2e49f29c381ed82dc95aa642a7660b8' 
 -XPOST -d '{"name":"Tom Hardy", "username":"thardy",
 "email":"thardy@tendrl.org", "role":"admin", "password":"pass1234",
-"password_confirmation":"pass1234","email_notifications": true}'
+"email_notifications": true}'
 http://127.0.0.1/api/1.0/users
 ----------
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe UsersController do
           username: 'thardy',
           name: 'Tom Hardy',
           password: 'temp1234',
-          password_confirmation: 'temp1234',
           role: 'admin',
           email_notifications: true
         }

--- a/spec/forms/user_form_spec.rb
+++ b/spec/forms/user_form_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe Tendrl::UserForm do
       expect(validator.errors[:email].size).to eq(1)
       expect(validator.errors[:name].size).to eq(2)
       expect(validator.errors[:password].size).to eq(1)
-      expect(validator.errors[:password_confirmation].size).to eq(1)
       expect(validator.errors[:role].size).to eq(1)
       expect(validator.errors[:email_notifications].size).to eq(1)
     end
@@ -31,7 +30,6 @@ RSpec.describe Tendrl::UserForm do
         email: 'tom@tendrl.org',
         username: 'thardy',
         password: 'temp1234',
-        password_confirmation: 'temp1234',
         role: Tendrl::User::ADMIN,
         email_notifications: true
       })
@@ -44,7 +42,6 @@ RSpec.describe Tendrl::UserForm do
         email: 'dwarner@tendrl.org',
         username: 'dwarner',
         password: 'temp1234',
-        password_confirmation: 'temp1234',
         email_notifications: true,
         role: Tendrl::User::ADMIN
       })
@@ -72,7 +69,6 @@ RSpec.describe Tendrl::UserForm do
     it 'with valid attributes and invalid password' do
       validator = UserForm.new(user, {
         password: 'temp',
-        password_confirmation: 'temp',
         role: Tendrl::User::NORMAL
       })
       expect(validator.valid?).to eq(false)
@@ -85,7 +81,6 @@ RSpec.describe Tendrl::UserForm do
         email: 'tom@tendrl.org',
         username: 'thardy',
         password: 'temp1234',
-        password_confirmation: 'temp1234',
         role: Tendrl::User::NORMAL
       })
       expect(validator.valid?).to eq(true)
@@ -97,7 +92,6 @@ RSpec.describe Tendrl::UserForm do
         email: 'dwarner@tendrl.org',
         username: 'dwarner',
         password: 'temp1234',
-        password_confirmation: 'temp1234',
         role: Tendrl::User::LIMITED
       })
       expect(validator.valid?).to eq(true)


### PR DESCRIPTION
This is backward-compatible because unknown parameters are simply
ignored.

Fixes: #106