### PR TITLE
Bugfix for expand edge case

### DIFF
--- a/app/controllers/clusters_controller.rb
+++ b/app/controllers/clusters_controller.rb
@@ -88,6 +88,7 @@ class ClustersController < AuthenticatedUsersController
   end
 
   post '/clusters/:cluster_id/expand' do
+    load_node_definitions
     flow = Tendrl::Flow.new 'namespace.tendrl', 'ExpandClusterWithDetectedPeers'
     job = Tendrl::Job.new(
       current_user,


### PR DESCRIPTION
This fixes the expand API failing if it is the first API being hit after
service start.

Fixes: #400
tendrl-bug-id: Tendrl/api#400