### PR TITLE
Import job for unknown cluster now returns 404

### DIFF
--- a/spec/controllers/clusters_controller_spec.rb
+++ b/spec/controllers/clusters_controller_spec.rb
@@ -42,11 +42,11 @@ describe ClustersController do
   context 'import' do
     before do
       stub_definitions
-      stub_unmanaged_cluster
-      stub_job_creation
     end
 
     it 'unmanaged' do
+      stub_unmanaged_cluster
+      stub_job_creation
       body = {
         'Cluster.volume_profiling_flag' => "enable"
       }
@@ -56,6 +56,11 @@ describe ClustersController do
       expect(last_response.status).to eq 202
     end
 
+    specify 'unknown cluster' do
+      stub_unknown_cluster
+      post '/clusters/unknown/import', '{}', http_env
+      expect(last_response.status).to eq 404
+    end
   end
 
   context 'expand' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -192,6 +192,22 @@ def stub_job
   )
 end
 
+def stub_unknown_cluster
+  stub_request(
+    :get,
+    /http:\/\/127.0.0.1:4001\/v2\/keys\/clusters\/unknown/
+  ).
+  to_return(
+    :status => 404,
+    :body => {
+      "errorCode" => 100,
+      "message" =>  "Key not found",
+      "cause" => "/clusters/unknown",
+      "index"=> 51850
+    }.to_json
+  )
+end
+
 def stub_missing_job
   stub_request(
     :get,


### PR DESCRIPTION
Fixes: #397
tendrl-bug-id: Tendrl/api#397