### PR TITLE
Disallow updating username

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -35,7 +35,6 @@ class UsersController < AuthenticatedUsersController
     user_form = Tendrl::UserForm.new(user, user_attributes)
     if user_form.valid?
       attributes = user_form.attributes
-      attributes[:role] = user.role # Disallow updating role
       user = Tendrl::User.save(attributes)
       UserPresenter.single(user).to_json
     else

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -2,6 +2,7 @@ module Tendrl
   class UserForm
     include ActiveModel::Validations
 
+    attr_reader :user
     attr_accessor :name, :username, :email, :password,
       :role, :email_notifications
 
@@ -18,6 +19,13 @@ module Tendrl
     validates :role, inclusion: { in: Tendrl::User::ROLES }
 
     validate :uniqueness
+
+    validates_each :username, :role do |record, attr, value|
+      existing_value = record.user.public_send(attr)
+      if existing_value.present? && value != existing_value
+        record.errors.add(attr, 'cannot be changed')
+      end
+    end
 
     def initialize(user, params)
       @user = user
@@ -82,7 +90,5 @@ module Tendrl
         end
       end
     end
-
   end
 end
-

--- a/spec/forms/user_form_spec.rb
+++ b/spec/forms/user_form_spec.rb
@@ -52,16 +52,13 @@ RSpec.describe Tendrl::UserForm do
   end
 
   context 'update' do
-
     let(:user){
       stub_user('dwarner')
       Tendrl::User.find('dwarner')
     }
 
     it 'with valid attributes and no password' do
-      validator = UserForm.new(user, {
-        role: Tendrl::User::NORMAL
-      })
+      validator = UserForm.new(user, name: 'T Hardy')
       expect(validator.valid?).to eq(true)
     end
 
@@ -75,25 +72,37 @@ RSpec.describe Tendrl::UserForm do
     end
 
     it 'with valid attributes and password' do
-      validator = UserForm.new(user, {
+      validator = UserForm.new(
+        user,
         name: 'Tom Hardy',
         email: 'tom@tendrl.org',
-        username: 'thardy',
         password: 'temp12345',
-        role: Tendrl::User::NORMAL
-      })
+      )
       expect(validator.valid?).to eq(true)
     end
 
     it 'with existing username/email' do
-      validator = UserForm.new(user, {
+      validator = UserForm.new(
+        user,
+        name: 'David Warner',
+        username: 'dwarner',
+        email: 'dwarner@tendrl.org',
+        password: 'temp12345'
+      )
+      expect(validator.valid?).to eq(true)
+    end
+
+    specify 'with different username or role not allowed' do
+      validator = UserForm.new(
+        user,
         name: 'David Warner',
         email: 'dwarner@tendrl.org',
-        username: 'dwarner',
+        username: 'thardy',
         password: 'temp12345',
         role: Tendrl::User::LIMITED
-      })
-      expect(validator.valid?).to eq(true)
+      )
+      expect(validator.valid?).to eq(false)
+      expect(validator.errors.messages.keys).to include(:username, :role)
     end
   end
 end


### PR DESCRIPTION
bugzilla: 1610660

Since etcd does not allow renaming of keys, the only way to fix this is
to delete the existing user once the new one is created. UI does not allow editing username anyway.