### PR TITLE
Handling json marshal exception when brick disk, partition, LV details are empty

### DIFF
--- a/app/presenters/brick_presenter.rb
+++ b/app/presenters/brick_presenter.rb
@@ -3,7 +3,7 @@ module BrickPresenter
     def list(bricks)
       bricks.map do |attributes|
         %w[devices partitions pv].each do |key|
-          attributes[key] = JSON.parse(attributes[key] || '[]')
+          attributes[key] = JSON.parse(attributes[key] || '[]') rescue {}
         end
         attributes
       end


### PR DESCRIPTION
I have removed blivet dependency from gluster-integration, for now
we have the only disks, partitions will be populated lv details we will add in future
so I am handling json parse exception when lv anyone details come empty

bugzilla: 1637977
tendrl-bug-id: Tendrl/api/issues#450

Signed-off-by: GowthamShanmugam <gshanmug@redhat.com>